### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/02-EXPORT.t
+++ b/t/02-EXPORT.t
@@ -1,16 +1,16 @@
 use Test;
 
-eval_lives_ok q{
+eval-lives-ok q{
     use ADT "Tree = Branch Tree left, Tree right | Leaf Str storage";
     my $a = Tree.new-leaf("Hello");
 }, "single ADT from EXPORT";
 
-eval_lives_ok q{
+eval-lives-ok q{
     use ADT "Maybe = Just Str data | Nothing";
     my $a = Maybe.new-just("Hello");
 }, "single ADT from EXPORT number 2";
 
-eval_lives_ok q{
+eval-lives-ok q{
     use ADT "Maybe = Just Str data | Nothing", "Tree = Branch Tree left, Tree right | Leaf Str storage";
     my $a = Maybe.new-just("Hello");
     my $b = Tree.new-leaf("Goodbye"); 

--- a/t/04-whitespace.t
+++ b/t/04-whitespace.t
@@ -3,7 +3,7 @@ use ADT;
 plan 5;
 
 {
-    dies_ok { create_adt("arghlebarghle") }, "sanity";
+    dies-ok { create_adt("arghlebarghle") }, "sanity";
 
     ok create_adt(q:to/TREE/), "simple multiline";
         Tree = Branch Tree left, Tree right


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.