### PR TITLE
Also generate a "raku" method

### DIFF
--- a/lib/ADT.pm6
+++ b/lib/ADT.pm6
@@ -160,7 +160,7 @@ module ADT {
         }
 
         # create a pretty-printer
-        for <perl gist> -> $methname {
+        for <raku perl gist> -> $methname {
             $container-type.HOW.add_method($container-type, $methname, method {
                     for %constructors.keys {
                         if self."$_.lc()"().defined {


### PR DESCRIPTION
This appears to be needed after the .perl / .raku rename in the setting.  I'm not sure why, but that makes the module survive that change.